### PR TITLE
Fix: Resolve Supabase import and RLS errors, fix VeureHotels display

### DIFF
--- a/apphotel.js
+++ b/apphotel.js
@@ -59,6 +59,36 @@ Hotels.push(Hotel3);
 
 var Hotel4= new hotel("Cosmos", 400,16,6000);
 Hotels.push(Hotel4);
+
+let visual;
+let valor1;
+let valor2;
+let valor3;*/
+
+    // First, get the target element
+    const llistatHotelsElement = document.getElementById("LlistatHotels");
+
+    // Check if the element exists
+    if (!llistatHotelsElement) {
+        console.error("Error: Element with ID 'LlistatHotels' not found in the DOM.");
+        // Optionally, display a message to the user in another way if appropriate
+        // For example, alert("Could not find where to display the hotels.");
+        return; // Exit the function if the element isn't found
+    }
+
+	/*var Hotels=[ ]; // This local array is now populated from Supabase
+var Hotel1= new hotel("sofia",500,12,1400);
+Hotels.push(Hotel1);
+
+var Hotel2= new hotel("cleopatra",1000,10,2800);
+Hotels.push(Hotel2);
+
+
+var Hotel3= new hotel("Palais", 200,8,3000);
+Hotels.push(Hotel3);
+
+var Hotel4= new hotel("Cosmos", 400,16,6000);
+Hotels.push(Hotel4);
 	
 let visual;
 let valor1;
@@ -85,7 +115,8 @@ for (var i = 0; i < Hotels.length; i++) {
 }
 
 // Actualitzem l'element HTML amb l'ID "LlistatHotels"
-document.getElementById("LlistatHotels").innerHTML = output;
+    // Now, safely set the innerHTML because we know llistatHotelsElement exists
+    llistatHotelsElement.innerHTML = output;
 
 
 

--- a/supabaseClient.js
+++ b/supabaseClient.js
@@ -1,4 +1,4 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
 
 // Supabase project URL
 const supabaseUrl = 'https://gtucfltpqrmftekcvgmd.supabase.co';


### PR DESCRIPTION
- Modified supabaseClient.js to use CDN import for @supabase/supabase-js to resolve bare specifier error.
- Guided user to update Supabase RLS policies to allow insert and select, resolving 'violates row-level security policy' error.
- Added a null check in VeureHotels function in apphotel.js to prevent 'document.getElementById(...) is null' error and ensure hotel list displays correctly.