### PR TITLE
Style: Apply Tailwind CSS to topnav and input buttons

### DIFF
--- a/hotels.css
+++ b/hotels.css
@@ -30,20 +30,13 @@
   
   /* Style the topnav links */
   .topnav a {
-   
-    display: inline-block;
-    color: #f2f2f2;
-    text-align: center;
-    padding: 14px 16px;
-    text-decoration: none;
+    @apply bg-[#322f20ff] text-white py-3 px-4 hover:bg-gray-700; /* Tailwind classes for topnav buttons */
+    /* Ensure these are the last rules to override any defaults if necessary */
+    display: inline-block; /* Kept for compatibility if Tailwind's display classes are not sufficient */
+    text-align: center; /* Kept for compatibility */
+    text-decoration: none; /* Kept for compatibility */
   }
   
-  /* Change color on hover */
-  .topnav a:hover {
-    background-color: #ddd;
-    color: black;
-  }
-
   body, html {
     margin: 0;
     padding: 0;
@@ -97,29 +90,12 @@
   input[type="button"], 
     input[type="submit"], 
     input[type="reset"] {
-    background-color: #007bff; /* Color de fons blau */
-    color: white; /* Color del text blanc */
-    border: none; /* Sense borderes */
-    padding: 10px 20px; /* Espai intern */
-    font-size: 16px; /* Mida de la lletra */
-    cursor: pointer; /* Cursor de mà */
-    border-radius: 5px; /* Cantonades arrodonides */
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* Sombrejat */
-    transition: background-color 0.3s, box-shadow 0.3s; /* Transició suau */
-    }
-
-    input[type="button"]:hover, 
-    input[type="submit"]:hover, 
-    input[type="reset"]:hover {
-    background-color: #0056b3; /* Color de fons blau més fosc al passar el cursor */
-    box-shadow: 0 6px 8px rgba(0, 0, 0, 0.15); /* Sombrejat més intens */
-    }
-
-    input[type="button"]:active, 
-    input[type="submit"]:active, 
-    input[type="reset"]:active {
-    background-color: #004494; /* Color de fons blau encara més fosc al fer clic */
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2); /* Sombrejat més suau */
+    @apply bg-[#322f20ff] text-white py-2 px-4 rounded shadow-md hover:bg-gray-700 active:bg-gray-800; /* Tailwind classes for input buttons */
+    /* Ensure these are the last rules to override any defaults if necessary */
+    border: none; /* Kept for compatibility */
+    cursor: pointer; /* Kept for compatibility */
+    font-size: 16px; /* Kept for compatibility */
+    /* transition and box-shadow are handled by Tailwind's utilities like shadow-md and hover/active states */
     }
 
   .llista{


### PR DESCRIPTION
- Updated `hotels.css` to use Tailwind CSS utility classes for buttons in the `topnav` and `input` elements.
- Applied the black olive color scheme (#322f20ff) as requested.
- Removed previous CSS rules for these elements to avoid conflicts.
- This change aims to improve responsiveness and maintainability of button styles.